### PR TITLE
Fix: small error in canUpdateRoom

### DIFF
--- a/Components/DungeonMap.js
+++ b/Components/DungeonMap.js
@@ -1565,7 +1565,7 @@ class DungeonMap {
             this.getBlockIdAt(x + 32 - 1, roofY, y + 32 - 1) === 0 &&
             this.getBlockIdAt(x + 32 - 1, roofY, y + 32) !== 0 &&
             this.getBlockIdAt(x + 32, roofY, y + 32 - 1) !== 0) { // Forth iteration incase of L shape
-            y += 32
+            x += 32
         }
 
         let rotation = this.getRotation(x, y, width, height, roofY);

--- a/Components/DungeonMap.js
+++ b/Components/DungeonMap.js
@@ -1475,11 +1475,10 @@ class DungeonMap {
     }
 
     /**
-     * @returns {[Number, Number]} the x and y location of the rooms 'location' (top left of all rooms, shifting down by 1 if needed to in L)
+     * @returns {[Number, Number]} the x and y location of the rooms 'location' (top left of all rooms, shifted down by 1 if needed to in L)
      */
     getRoomXYWorld() {
         let roomData = this.getRoomWorldData()
-        if (roomData.rotation === 4) return [roomData.x, roomData.y + 32]
         return [roomData.x, roomData.y]
     }
 
@@ -1561,6 +1560,12 @@ class DungeonMap {
             && this.getBlockIdAt(x - 1 + (width === 30 ? 0 : 32), roofY, y + height) !== 0) { // Third iteration incase of L shape
             x -= 32
             width += 32
+        }
+        while (width > 30 && height > 30
+            && this.getBlockIdAt(x + 32 - 1, roofY, y + 32 - 1) === 0
+            && this.getBlockIdAt(x + 32 - 1, roofY, y + 32) !== 0
+            && this.getBlockIdAt(x + 32, roofY, y + 32 - 1) !== 0) { // Forth iteration incase of L shape
+            y += 32
         }
 
         let rotation = this.getRotation(x, y, width, height, roofY);

--- a/Components/DungeonMap.js
+++ b/Components/DungeonMap.js
@@ -1475,7 +1475,7 @@ class DungeonMap {
     }
 
     /**
-     * @returns {[Number, Number]} the x and y location of the rooms 'location' (top left of all rooms, shifted down by 1 if needed to in L)
+     * @returns {[Number, Number]} the x and y location of the rooms 'location' (top left of all rooms, shifted right by 1 if needed to in L)
      */
     getRoomXYWorld() {
         let roomData = this.getRoomWorldData()

--- a/Components/DungeonMap.js
+++ b/Components/DungeonMap.js
@@ -1561,10 +1561,10 @@ class DungeonMap {
             x -= 32
             width += 32
         }
-        while (width > 30 && height > 30
-            && this.getBlockIdAt(x + 32 - 1, roofY, y + 32 - 1) === 0
-            && this.getBlockIdAt(x + 32 - 1, roofY, y + 32) !== 0
-            && this.getBlockIdAt(x + 32, roofY, y + 32 - 1) !== 0) { // Forth iteration incase of L shape
+        while (width > 30 && height > 30 &&
+            this.getBlockIdAt(x + 32 - 1, roofY, y + 32 - 1) === 0 &&
+            this.getBlockIdAt(x + 32 - 1, roofY, y + 32) !== 0 &&
+            this.getBlockIdAt(x + 32, roofY, y + 32 - 1) !== 0) { // Forth iteration incase of L shape
             y += 32
         }
 


### PR DESCRIPTION
When there is an L shaped room with the missing part in the top left corner the mod incorrectly identified that corner as the start of the room instead of going 1 room down to where the actual room is. It seemed at some point this was identified by if rotation was set to 4 but currently in the code this is not done anywhere.
Also instead of setting the corner to the one below like the current code I have set it to the one to the right as this matches where the checkmarks are displayed on the bettermap map

Image of map:
![image](https://github.com/BetterMap/BetterMap/assets/94038482/710a9a3c-9198-4093-949a-d0496468f20f)

Difference in location (ct is current module, mod is changed to fix the issue)
![image](https://github.com/BetterMap/BetterMap/assets/94038482/3f590b8e-d5e0-42ac-9648-577e012d3cce)

When entering that top left room the ct module doesnt detect the change but the changed version does, this means for a tiny bit the wrong data can be set for the wrong room (e.g. Blood room is given secrets)
![image](https://github.com/BetterMap/BetterMap/assets/94038482/1ea77a69-8c47-4aec-a788-1331b87aff38)
